### PR TITLE
Fix `canvas` size on Chrome for Android

### DIFF
--- a/browser_wasm.go
+++ b/browser_wasm.go
@@ -53,7 +53,7 @@ func CreateWindow(_, _ int, title string, monitor *Monitor, share *Window) (*Win
 	canvas.Set("width", int(float64(width)*devicePixelRatio+0.5))   // Nearest non-negative int.
 	canvas.Set("height", int(float64(height)*devicePixelRatio+0.5)) // Nearest non-negative int.
 
-	// Use dynamic viewport units (dvw and dvh) if available, and use vw and vh as fallback.
+	// Use dvw and dvh if supported; otherwise, fall back to vw and vh.
 	canvas.Get("style").Call("setProperty", "width", "100vw")
 	canvas.Get("style").Call("setProperty", "width", "100dvw")
 	canvas.Get("style").Call("setProperty", "height", "100vh")


### PR DESCRIPTION
## Closes https://github.com/fyne-io/demo.fyne.io/issues/4

My shabby Android device[^1] running Google Chrome displayed a blank page when visiting [demo.fyne.io](https://demo.fyne.io). Nevertheless, Mozilla Firefox on the same device rendered the page correctly.

It turns out that on Google Chrome `100vh` was way taller than the actual viewport height, and the `canvas` element was so tall that all the Fyne graphical elements were being rendered "somewhere" outside the viewport. 

Using [`dvh`](https://www.w3.org/TR/css-values-4/#dynamic-viewport-percentage-units) units instead of `vh` units was the simplest solution I could think of, and it seems to be a [relatively](https://caniuse.com/viewport-unit-variants) well-supported feature.

I have tested this fix in several mobile and desktop browsers, and all of them seem to behave correctly:

* iPad Pro 12.9" (iPadOS 18.1 + Google Chrome 130.0.6723.90)
* iMac 27" (macOS 10.15.7 + Google Chrome 128.0.6613.138)
* Redmi Note 11S (Android 11 + Google Chrome 130.0.6723.102)

### Screenshots

Before | After
--- | ---
![Screenshot_2024-11-20-04-30-03-232_com android chrome](https://github.com/user-attachments/assets/a3186f25-75bf-418d-bc34-2f1bab77cfb6) | ![Screenshot_2024-11-20-04-29-49-357_com android chrome](https://github.com/user-attachments/assets/795546a4-b0d1-4019-8883-82da9f58ca3e)

[^1]: Redmi Note 11S (Android 11 + Google Chrome 130.0.6723.102)