### PR TITLE
Move clipboard handling away from window

### DIFF
--- a/browser_wasm.go
+++ b/browser_wasm.go
@@ -964,30 +964,10 @@ func DefaultWindowHints() {
 }
 
 func (w *Window) SetClipboardString(str string) {
-	// Set the clipboard content from the input str
-	js.Global().Get("navigator").Get("clipboard").Call("writeText", str)
+	SetClipboardString(str)
 }
-func (w *Window) GetClipboardString() (string, error) {
-	// Get the clipboard object.
-	clipboard := js.Global().Get("navigator").Get("clipboard")
-	clipboardChan := make(chan js.Value)
-	// Call the `readText()` function and send the result to the channel
-	clipboard.Call("readText").Call("then", js.FuncOf(func(this js.Value, p []js.Value) interface{} {
-		clipboardContent := p[0]
-		clipboardChan <- clipboardContent
-		return nil
-	})).Call("catch", js.FuncOf(func(this js.Value, args []js.Value) interface{} {
-		clipboardChan <- js.ValueOf(nil)
-		return nil
-	}))
-	// Get the js.Value of the clipboard text from the channel
-	result := <-clipboardChan
-	if result.Truthy() {
-		// Convert the value to a string and return the value
-		text := result.String()
-		return text, nil
-	}
-	return "", errors.New("Failed to get clipboard text")
+func (w *Window) GetClipboardString() string {
+	return GetClipboardString()
 }
 
 func (w *Window) SetTitle(title string) {

--- a/clipboard_glfw.go
+++ b/clipboard_glfw.go
@@ -1,0 +1,19 @@
+//go:build !wasm
+
+package glfw
+
+import "github.com/go-gl/glfw/v3.3/glfw"
+
+// GetClipboardString returns the contents of the system clipboard, if it contains or is convertible to a UTF-8 encoded string.
+//
+// This function may only be called from the main thread.
+func GetClipboardString() string {
+	return glfw.GetClipboardString()
+}
+
+// SetClipboardString sets the system clipboard to the specified UTF-8 encoded string.
+//
+// This function may only be called from the main thread.
+func SetClipboardString(text string) {
+	glfw.SetClipboardString(text)
+}

--- a/clipboard_wasm.go
+++ b/clipboard_wasm.go
@@ -1,0 +1,38 @@
+//go:build wasm
+
+package glfw
+
+import (
+	"syscall/js"
+)
+
+// GetClipboardString returns the contents of the system clipboard, if it contains or is convertible to a UTF-8 encoded string.
+//
+// This function may only be called from the main thread.
+func GetClipboardString() string {
+	clipboard := js.Global().Get("navigator").Get("clipboard")
+	clipboardChan := make(chan js.Value)
+
+	clipboard.Call("readText").Call("then", js.FuncOf(func(this js.Value, p []js.Value) interface{} {
+		clipboardContent := p[0]
+		clipboardChan <- clipboardContent
+		return nil
+	})).Call("catch", js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+		clipboardChan <- js.ValueOf(nil)
+		return nil
+	}))
+
+	result := <-clipboardChan
+	if !result.Truthy() {
+		return ""
+	}
+
+	return result.String()
+}
+
+// SetClipboardString sets the system clipboard to the specified UTF-8 encoded string.
+//
+// This function may only be called from the main thread.
+func SetClipboardString(str string) {
+	js.Global().Get("navigator").Get("clipboard").Call("writeText", str)
+}


### PR DESCRIPTION
To be consistent with recommendations from upstream glfw and v2.6.0 moving clipboard to app, we should move these out from the window. I also corrected the API to match the upstream API.