### PR TITLE
Fix: add missing goroutine when callback from Javascript

### DIFF
--- a/browser_wasm.go
+++ b/browser_wasm.go
@@ -119,14 +119,14 @@ func CreateWindow(_, _ int, title string, monitor *Monitor, share *Window) (*Win
 
 	addGlobalEventListener.Invoke("focus", newJsFuncFrom(func(this js.Value, args []js.Value) any {
 		if w.focusCallback != nil {
-			w.focusCallback(w, true)
+			go w.focusCallback(w, true)
 		}
 		return nil
 	}))
 
 	addGlobalEventListener.Invoke("blur", newJsFuncFrom(func(this js.Value, args []js.Value) any {
 		if w.focusCallback != nil {
-			w.focusCallback(w, false)
+			go w.focusCallback(w, false)
 		}
 		return nil
 	}))
@@ -329,7 +329,7 @@ func CreateWindow(_, _ int, title string, monitor *Monitor, share *Window) (*Win
 
 	addDocumentEventListener.Invoke("beforeUnload", newJsFuncFrom(func(this js.Value, args []js.Value) any {
 		if w.closeCallback != nil {
-			w.closeCallback(w)
+			go w.closeCallback(w)
 		}
 		return nil
 	}))


### PR DESCRIPTION
This work is essential before addressing https://github.com/fyne-io/demo.fyne.io/issues/23

See for more details why
https://github.com/golang/go/blob/c697e0fc482de62da72d4470ac082bf5e5720642/src/syscall/js/func.go#L38-L42

> // As a consequence, if one wrapped function blocks, JavaScript's event loop
> // is blocked until that function returns. Hence, calling any async JavaScript
> // API, which requires the event loop, like fetch (http.Client), will cause an
> // immediate deadlock. Therefore a blocking function should explicitly start a
> // new goroutine.